### PR TITLE
Update manifest.toml

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -61,4 +61,6 @@ ram.runtime = "100K"
     # The initial allowed group of user is configured via the init_main_permission question (public=visitors, private=all_users)
     main.url = "/"
     main.allowed = "all_users"
+    main.auth_header = "true"
+    main.protected = "true"
 	


### PR DESCRIPTION
protect against permissiong to visitors.

## Problem

- some users tried to give access to visitors and they could not suppress the permission. 
- It seems that this permission change the "auth-header" parameter

## Solution

- change ressources parameters in the manifest

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
